### PR TITLE
Updated preload register according to P5 0.7.2

### DIFF
--- a/p5.geolocation.js
+++ b/p5.geolocation.js
@@ -72,7 +72,7 @@ p5.prototype.getCurrentPosition = function(callback, errorCallback) {
 };
 
 //add the get Current position to the preload stack.
-p5.prototype.registerPreloadMethod('getCurrentPosition');
+p5.prototype.registerPreloadMethod('getCurrentPosition', p5.prototype);
 
 /**
 * Get User's Current Position on an interval


### PR DESCRIPTION
Fixes #8. With the new version of P5, this library would broke the `preload()` function. This means that even if you do nothing with p5.geolocation, if you have instruction in the `preload()` function thee sketch won't work.

In the latest P5 version, `prototype.registerPreloadMethod` requires two parameters, [see reference](https://github.com/processing/p5.js/blob/master/developer_docs/creating_libraries.md#use-registerpreloadmethod-to-register-names-of-methods-with-p5-that-may-be-called-in-preload).

Tested with some basic sketches and it seems to work now. Maybe a deeper check would be needed.

